### PR TITLE
feat: display current year in footer

### DIFF
--- a/src/app/shared/footer/footer.component.ts
+++ b/src/app/shared/footer/footer.component.ts
@@ -48,11 +48,11 @@ import { RouterLink } from '@angular/router';
         </div>
       </div>
       <div class="border-t border-slate-200">
-        <div class="container py-4 text-sm text-slate-600">
-          © {{ 2025 }} World is One Family
-        </div>
+        <div class="container py-4 text-sm text-slate-600">© {{ year }} World is One Family</div>
       </div>
     </footer>
   `,
 })
-export class FooterComponent {}
+export class FooterComponent {
+  year = new Date().getFullYear();
+}


### PR DESCRIPTION
## Summary
- replace hardcoded footer year with `{{ year }}`
- compute `year` from `new Date().getFullYear()`

## Testing
- `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: Could not resolve "./app"; TS2307: Cannot find module './app')*


------
https://chatgpt.com/codex/tasks/task_e_68b7308c559c832aa20be7f0fbd9ba48