### PR TITLE
feat: update element routing

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -12,7 +12,7 @@ export const routes: Routes = [
   },
   // app.routes.ts
   {
-    path: 'elements',
+    path: 'element',
     loadChildren: () => import('./features/elements/elements.routes').then((m) => m.ELEMENT_ROUTES),
   },
   {

--- a/src/app/features/elements/elements.routes.ts
+++ b/src/app/features/elements/elements.routes.ts
@@ -2,6 +2,7 @@
 import { Routes } from '@angular/router';
 
 export const ELEMENT_ROUTES: Routes = [
+  { path: '', pathMatch: 'full', redirectTo: 'earth' },
   {
     path: ':element',
     loadComponent: () => import('./element-shell.component').then((m) => m.ElementShellComponent),

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -27,7 +27,7 @@ import { ElementBadgeComponent } from '../../shared/ui/element-badge.component';
             share for a thriving planet.
           </p>
           <div class="mt-6 flex gap-3">
-            <a routerLink="/elements" class="px-5 py-3 rounded-xl bg-water text-white shadow-soft"
+            <a routerLink="/element" class="px-5 py-3 rounded-xl bg-water text-white shadow-soft"
               >Explore the Elements</a
             >
             <a routerLink="/videos" class="px-5 py-3 rounded-xl border border-slate-300"
@@ -54,7 +54,7 @@ import { ElementBadgeComponent } from '../../shared/ui/element-badge.component';
             <h2 class="section-title">Explore the Five Elements</h2>
             <p class="section-sub">Learn, practice and share by element.</p>
           </div>
-          <a routerLink="/elements" class="text-water">View all</a>
+          <a routerLink="/element" class="text-water">View all</a>
         </div>
         <div class="grid sm:grid-cols-2 lg:grid-cols-5 gap-4">
           <app-element-card

--- a/src/app/shared/footer/footer.component.ts
+++ b/src/app/shared/footer/footer.component.ts
@@ -20,7 +20,7 @@ import { RouterLink } from '@angular/router';
         <div>
           <h4 class="font-semibold mb-3">Explore</h4>
           <ul class="space-y-2 text-slate-700">
-            <li><a routerLink="/elements">Elements</a></li>
+            <li><a routerLink="/element">Elements</a></li>
             <li><a routerLink="/videos">Videos</a></li>
             <li><a routerLink="/blog">Blog</a></li>
             <li><a routerLink="/about">About</a></li>

--- a/src/app/shared/header/header.component.ts
+++ b/src/app/shared/header/header.component.ts
@@ -15,7 +15,7 @@ import { RouterLink } from '@angular/router';
           <span>World is One Family</span>
         </a>
         <nav class="hidden md:flex items-center gap-6 text-sm">
-          <a routerLink="/elements" class="hover:text-water">Elements</a>
+          <a routerLink="/element" class="hover:text-water">Elements</a>
           <a routerLink="/videos" class="hover:text-water">Videos</a>
           <a routerLink="/blog" class="hover:text-water">Blog</a>
           <a routerLink="/about" class="hover:text-water">About</a>

--- a/src/app/shared/ui/element-card.component.ts
+++ b/src/app/shared/ui/element-card.component.ts
@@ -8,8 +8,7 @@ import { RouterLink } from '@angular/router';
   imports: [RouterLink, NgStyle],
   template: `
     <a
-      [routerLink]="['/elements']"
-      [queryParams]="{ t: tag }"
+      [routerLink]="['/element', tag]"
       class="card p-6 flex flex-col gap-3 hover:shadow-lg transition"
     >
       <div class="w-12 h-12 rounded-2xl" [ngStyle]="{ background: gradient }"></div>


### PR DESCRIPTION
## Summary
- rename root route to `/element`
- update element links to `['/element', tag]`
- adjust navigation to new element path and add default redirect

## Testing
- `npm test -- --watch=false` *(fails: Could not resolve "./app" in app.spec.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68b82ebfcd54832ab70ac4ae638354c8