### PR TITLE
feat: add mock content for placeholder pages

### DIFF
--- a/src/app/features/about/about.component.ts
+++ b/src/app/features/about/about.component.ts
@@ -5,9 +5,18 @@ import { Component } from '@angular/core';
   standalone: true,
   template: `
     <section class="section">
-      <div class="container">
+      <div class="container prose">
         <h1 class="section-title">About Us</h1>
-        <p class="section-sub">Coming soon…</p>
+        <p class="section-sub mb-8">Learn more about the World is One Family initiative.</p>
+        <p>
+          World is One Family is a collective movement dedicated to living in harmony with the five
+          elements—earth, water, fire, air and space. We share stories, tools and actions to inspire
+          sustainable living.
+        </p>
+        <p>
+          This mock page showcases the type of content that will appear here in the future,
+          including our mission, team and history.
+        </p>
       </div>
     </section>
   `,

--- a/src/app/features/contact/contact.component.ts
+++ b/src/app/features/contact/contact.component.ts
@@ -3,6 +3,34 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-contact',
   standalone: true,
-  template: `<section class="section"><div class="container"><h1 class="section-title">Contact</h1><p class="section-sub">Coming soon…</p></div></section>`
+  template: `
+    <section class="section">
+      <div class="container">
+        <h1 class="section-title">Contact</h1>
+        <p class="section-sub mb-8">We'd love to hear from you. Send us a message!</p>
+
+        <form class="max-w-xl space-y-4">
+          <input
+            type="text"
+            placeholder="Your name"
+            class="w-full border border-slate-300 rounded-xl px-3 py-2"
+          />
+          <input
+            type="email"
+            placeholder="you@example.com"
+            class="w-full border border-slate-300 rounded-xl px-3 py-2"
+          />
+          <textarea
+            rows="5"
+            placeholder="Your message"
+            class="w-full border border-slate-300 rounded-xl px-3 py-2"
+          ></textarea>
+          <button type="button" class="px-6 py-3 rounded-xl bg-water text-white">
+            Send Message
+          </button>
+        </form>
+      </div>
+    </section>
+  `,
 })
 export class ContactComponent {}

--- a/src/app/features/donate/donate.component.ts
+++ b/src/app/features/donate/donate.component.ts
@@ -3,6 +3,30 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-donate',
   standalone: true,
-  template: `<section class="section"><div class="container"><h1 class="section-title">Donate</h1><p class="section-sub">Coming soon…</p></div></section>`
+  template: `
+    <section class="section">
+      <div class="container">
+        <h1 class="section-title">Donate</h1>
+        <p class="section-sub mb-8">Support our mission with a contribution.</p>
+        <div class="grid sm:grid-cols-3 gap-4 max-w-3xl">
+          <div class="card p-6 text-center">
+            <h3 class="text-xl font-semibold mb-2">$10</h3>
+            <p class="text-slate-600 mb-4">Help plant a tree</p>
+            <button class="px-4 py-2 rounded-xl bg-water text-white w-full">Select</button>
+          </div>
+          <div class="card p-6 text-center">
+            <h3 class="text-xl font-semibold mb-2">$25</h3>
+            <p class="text-slate-600 mb-4">Provide clean water</p>
+            <button class="px-4 py-2 rounded-xl bg-water text-white w-full">Select</button>
+          </div>
+          <div class="card p-6 text-center">
+            <h3 class="text-xl font-semibold mb-2">$50</h3>
+            <p class="text-slate-600 mb-4">Support outreach programs</p>
+            <button class="px-4 py-2 rounded-xl bg-water text-white w-full">Select</button>
+          </div>
+        </div>
+      </div>
+    </section>
+  `,
 })
 export class DonateComponent {}

--- a/src/app/features/quiz/quiz-archive.component.ts
+++ b/src/app/features/quiz/quiz-archive.component.ts
@@ -1,8 +1,46 @@
 import { Component } from '@angular/core';
+import { NgFor } from '@angular/common';
+import { RouterLink } from '@angular/router';
 
 @Component({
   selector: 'app-quiz-archive',
   standalone: true,
-  template: `<section class="section"><div class="container"><h1 class="section-title">Quiz Archive</h1><p class="section-sub">Coming soon…</p></div></section>`
+  imports: [NgFor, RouterLink],
+  template: `
+    <section class="section">
+      <div class="container">
+        <h1 class="section-title">Quiz Archive</h1>
+        <p class="section-sub mb-6">Browse previous quizzes and test your knowledge.</p>
+        <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <a
+            *ngFor="let quiz of quizzes"
+            [routerLink]="['/quiz', quiz.slug]"
+            class="card p-4 block"
+          >
+            <h3 class="font-semibold mb-1">{{ quiz.title }}</h3>
+            <p class="text-slate-600 text-sm">{{ quiz.description }}</p>
+          </a>
+        </div>
+      </div>
+    </section>
+  `,
 })
-export class QuizArchiveComponent {}
+export class QuizArchiveComponent {
+  quizzes = [
+    {
+      title: 'Earth Day Challenge',
+      slug: 'earth-day-challenge',
+      description: 'Test your knowledge about protecting the planet.',
+    },
+    {
+      title: 'Water Conservation Quiz',
+      slug: 'water-conservation',
+      description: 'How much do you know about saving water?',
+    },
+    {
+      title: 'Clean Air Awareness',
+      slug: 'clean-air',
+      description: 'Learn about air pollution and solutions.',
+    },
+  ];
+}

--- a/src/app/features/videos/videos.component.ts
+++ b/src/app/features/videos/videos.component.ts
@@ -1,15 +1,51 @@
 import { Component } from '@angular/core';
+import { NgFor } from '@angular/common';
+import { VideoCardComponent, VideoCardModel } from '../../shared/ui/video-card.component';
 
 @Component({
   selector: 'app-videos',
   standalone: true,
+  imports: [NgFor, VideoCardComponent],
   template: `
     <section class="section">
       <div class="container">
         <h1 class="section-title">Videos</h1>
-        <p class="section-sub">Video grid coming soon…</p>
+        <p class="section-sub mb-6">Watch and share inspiring stories.</p>
+        <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          <app-video-card
+            *ngFor="let v of videos"
+            [title]="v.title"
+            [slug]="v.slug"
+            [thumbnailUrl]="v.thumbnailUrl"
+            [element]="v.element"
+          />
+        </div>
       </div>
     </section>
   `,
 })
-export class VideosComponent {}
+export class VideosComponent {
+  videos: VideoCardModel[] = [
+    {
+      title: 'Why Water Matters',
+      slug: 'why-water-matters',
+      thumbnailUrl:
+        'https://images.unsplash.com/photo-1508610048659-a06b669e3321?q=80&w=1200&auto=format&fit=crop',
+      element: 'water',
+    },
+    {
+      title: 'Plant a Tree Today',
+      slug: 'plant-a-tree',
+      thumbnailUrl:
+        'https://images.unsplash.com/photo-1501004318641-b39e6451bec6?q=80&w=1200&auto=format&fit=crop',
+      element: 'earth',
+    },
+    {
+      title: 'Breath and Balance',
+      slug: 'breath-and-balance',
+      thumbnailUrl:
+        'https://images.unsplash.com/photo-1469474968028-56623f02e42e?q=80&w=1200&auto=format&fit=crop',
+      element: 'air',
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- replace About placeholder with mission text
- add simple contact form
- mock donation tiers
- show quiz archive grid with sample quizzes
- render video gallery using sample data

## Testing
- `npm test -- --watch=false` *(fails: Invalid state: Controller is already closed)*


------
https://chatgpt.com/codex/tasks/task_e_68b94634ad48832abc732b6196ec9b46